### PR TITLE
Extract text from websites returned from google search API

### DIFF
--- a/webscrape.py
+++ b/webscrape.py
@@ -1,10 +1,13 @@
 import requests
 from bs4 import BeautifulSoup
+from goose3 import Goose
 
-API_KEY = "PUT_KEY"
-CX = "SEARCH_ENGINE_ID"
-query = "string query"
-num_results = 5
+API_KEY = "[API Key]"
+CX = "[Cx number]"
+query = "[Query String]"
+num_results = 2
+
+g = Goose()
 
 url = f"https://www.googleapis.com/customsearch/v1?key={API_KEY}&cx={CX}&q={query}&num={num_results}"
 
@@ -14,8 +17,21 @@ if response.status_code == 200:
     data = response.json()
     # Extract and print the non-sponsored links
     for item in data.get("items", []):
+        link = item["link"]
         print(item["title"])
-        print(item["link"])
+        print(f"Link: {link}")
+
+        #Visit each link and extract the text from each link
+        website_response = requests.get(link)
+
+        if website_response.status_code == 200:
+            #Find and extract the text content using goose3
+            article = g.extract(link)
+            main_text = article.cleaned_text
+            print(f"Text Content:\n{main_text}\n")
+        else:
+            print(f"Request website reponse failed with status code {website_response.status_code}\n")
+
 else:
     print(f"Request failed with status code {response.status_code}")
     print(response.content)


### PR DESCRIPTION
[Problem]
Need a method to extract text content from any web page returned from google search API

[Solution]
Use goose3 library to extract the main text from any given webpage. Functions from goose3 will automatically analyze the HTML page and extract all relevant content.

[Notes]
There is no current method of storing these relevant links. We are only printing them

resolves #3 